### PR TITLE
fix: use name instead of node_id

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -104,7 +104,7 @@ resource "github_branch_protection" "repos_branch_protection" {
   push_restrictions = [
     data.github_user.oc-ci-robot.node_id,
   ]
-  repository_id  = each.value.node_id
+  repository_id  = each.value.name
   pattern        = var.org_config.default_branch
 }
 


### PR DESCRIPTION
node_id is currently broken, see gh issue
https://github.com/integrations/terraform-provider-github/issues/908

Note that this means if the name changes the protection apply will break.